### PR TITLE
Change address structure to be in line with current address format

### DIFF
--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -347,46 +347,45 @@ addressee:
 
 address:
   description:
-    an address of a location/destination
+    An address of a location.
   type: object
   properties:
-    care_of:
-      description: |
-        (aka c/o) the person that resides at the address, if different from
-        addressee. E.g. used when sending a personal parcel to the
-        office /someone else's home where the addressee resides temporarily
-      type: string
-      example: Consulting Services GmbH
     street:
       description: |
-        the full street address including house number and street name
+        The street name, without number.
       type: string
-      example: Schönhauser Allee 103
-    additional:
+      example: Lübeckweg
+     number:
+        description: |
+          The house number.
+        type: integer
+        example: 2
+    complement:
       description: |
-        further details like building name, suite, apartment number, etc.
+        Optional house number suffixes.
       type: string
-      example: 2. Hinterhof rechts
+      example: A
     city:
       description: |
         name of the city / locality
       type: string
-      example: Berlin
-    zip:
+      example: Groningen
+    zipcode:
       description: |
         zip code or postal code
       type: string
-      example: 14265
+      example: 9723HE
     country_code:
       description: |
         the country code according to
         [iso-3166-1-alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
       type: string
-      example: DE
+      example: NL
   required:
     - street
+    - number
     - city
-    - zip
+    - zipcode
     - country_code
 ----
 


### PR DESCRIPTION
The current format as defined in the documentation is no in line with how addresses are stored at Spindle. Street for example contains the name of the street and the number. This will be extra overhead to use this information with the existing architecture. 

We don't use care_of, so that can be dropped. 

Renamed zip into zipcode to be in line with the current naming. 